### PR TITLE
Fix stateful auto-reset and refactor JSON parse bugs

### DIFF
--- a/src/handlers/ObjectDeletionHandlers.ts
+++ b/src/handlers/ObjectDeletionHandlers.ts
@@ -1,7 +1,7 @@
 import { McpError, ErrorCode } from "@modelcontextprotocol/sdk/types.js";
 import { BaseHandler } from './BaseHandler.js';
 import type { ToolDefinition } from '../types/tools.js';
-import { ADTClient } from "abap-adt-api";
+import { ADTClient, session_types } from "abap-adt-api";
 
 export class ObjectDeletionHandlers extends BaseHandler {
   getTools(): ToolDefinition[] {
@@ -44,6 +44,7 @@ export class ObjectDeletionHandlers extends BaseHandler {
   async handleDeleteObject(args: any): Promise<any> {
     const startTime = performance.now();
     try {
+      this.adtclient.stateful = session_types.stateful;
       const result = await this.adtclient.deleteObject(
         args.objectUrl,
         args.lockHandle,

--- a/src/handlers/ObjectLockHandlers.ts
+++ b/src/handlers/ObjectLockHandlers.ts
@@ -1,7 +1,7 @@
 import { McpError, ErrorCode } from "@modelcontextprotocol/sdk/types.js";
 import { BaseHandler } from './BaseHandler.js';
 import type { ToolDefinition } from '../types/tools.js';
-import { ADTClient } from "abap-adt-api";
+import { ADTClient, session_types } from "abap-adt-api";
 
 export class ObjectLockHandlers extends BaseHandler {
   getTools(): ToolDefinition[] {
@@ -56,6 +56,7 @@ export class ObjectLockHandlers extends BaseHandler {
   async handleLock(args: any): Promise<any> {
     const startTime = performance.now();
     try {
+      this.adtclient.stateful = session_types.stateful;
       const lockResult = await this.adtclient.lock(args.objectUrl, args.accessMode);
       this.trackRequest(startTime, true);
       return {
@@ -82,6 +83,7 @@ export class ObjectLockHandlers extends BaseHandler {
   async handleUnlock(args: any): Promise<any> {
     const startTime = performance.now();
     try {
+      this.adtclient.stateful = session_types.stateful;
       await this.adtclient.unLock(args.objectUrl, args.lockHandle);
       this.trackRequest(startTime, true);
       return {

--- a/src/handlers/ObjectSourceHandlers.ts
+++ b/src/handlers/ObjectSourceHandlers.ts
@@ -1,6 +1,7 @@
 import { McpError, ErrorCode } from "@modelcontextprotocol/sdk/types.js";
 import { BaseHandler } from './BaseHandler';
 import type { ToolDefinition } from '../types/tools';
+import { session_types } from 'abap-adt-api';
 
 export class ObjectSourceHandlers extends BaseHandler {
   getTools(): ToolDefinition[] {
@@ -71,9 +72,12 @@ export class ObjectSourceHandlers extends BaseHandler {
     }
   }
 
-  async handleSetObjectSource(args: any): Promise<any> {    
+  async handleSetObjectSource(args: any): Promise<any> {
     const startTime = performance.now();
     try {
+      // Library auto-resets stateful=stateless on dropSession/logout. Restore here
+      // so write operations get the correct X-sap-adt-sessiontype header.
+      this.adtclient.stateful = session_types.stateful;
       await this.adtclient.setObjectSource(
         args.objectSourceUrl,
         args.source,

--- a/src/handlers/RefactorHandlers.ts
+++ b/src/handlers/RefactorHandlers.ts
@@ -71,7 +71,8 @@ export class RefactorHandlers extends BaseHandler {
     async handleExtractMethodEvaluate(args: any): Promise<any> {
         const startTime = performance.now();
         try {
-            const result = await this.adtclient.extractMethodEvaluate(args.uri, args.range);
+            const range = typeof args.range === 'string' ? JSON.parse(args.range) : args.range;
+            const result = await this.adtclient.extractMethodEvaluate(args.uri, range);
             this.trackRequest(startTime, true);
             return {
                 content: [
@@ -96,7 +97,8 @@ export class RefactorHandlers extends BaseHandler {
     async handleExtractMethodPreview(args: any): Promise<any> {
         const startTime = performance.now();
         try {
-            const result = await this.adtclient.extractMethodPreview(args.proposal);
+            const proposal = typeof args.proposal === 'string' ? JSON.parse(args.proposal) : args.proposal;
+            const result = await this.adtclient.extractMethodPreview(proposal);
             this.trackRequest(startTime, true);
             return {
                 content: [
@@ -121,7 +123,8 @@ export class RefactorHandlers extends BaseHandler {
     async handleExtractMethodExecute(args: any): Promise<any> {
         const startTime = performance.now();
         try {
-            const result = await this.adtclient.extractMethodExecute(args.refactoring);
+            const refactoring = typeof args.refactoring === 'string' ? JSON.parse(args.refactoring) : args.refactoring;
+            const result = await this.adtclient.extractMethodExecute(refactoring);
             this.trackRequest(startTime, true);
             return {
                 content: [


### PR DESCRIPTION
## Summary

Two bugs in this wrapper prevent source-modifying operations from working. Both reproduce on a stock NW system; both fixes verified end-to-end (lock + setObjectSource + unLock + activate, and extractMethodEvaluate + Preview + Execute).

### 1. Stateful header reset to stateless after dropSession / logout

`abap-adt-api`'s `dropSession()` and `logout()` set `this.stateful = stateless` on the client. The server sets `stateful = stateful` once in `index.ts` (line 95) and never restores it. After any drop/logout — which is normal in long-running MCP sessions — every subsequent request sends `X-sap-adt-sessiontype: stateless`, and the SAP server rejects all write-side calls (`lock`, `setObjectSource`, `unLock`, `deleteObject`) with:

> `This operation can only be performed in stateful mode`

**Fix:** set `this.adtclient.stateful = session_types.stateful` at the top of each affected handler. `renameExecute` / `extractMethodExecute` are unaffected because the abap-adt-api refactoring methods don't depend on the session-type header in the same way.

### 2. RefactorHandlers pass string args to functions expecting objects

`RefactorHandlers.ts` declares `range`, `proposal`, `refactoring` as `string` in the input schemas, then passes the raw arg straight to `abap-adt-api`'s methods, which expect deserialized objects. Result on every `extractMethod*` call:

> `Cannot read properties of undefined (reading 'line')`

This is a pure wrapper bug — the underlying library is fine.

**Fix:** `JSON.parse` the string args in all three `handleExtractMethod*` handlers, with an object fallback for forward compat (so future schema changes to `type: 'object'` won't re-break things).

## Files changed

- `src/handlers/ObjectSourceHandlers.ts` — restore stateful before `setObjectSource`
- `src/handlers/ObjectLockHandlers.ts` — restore stateful before `lock` / `unLock`
- `src/handlers/ObjectDeletionHandlers.ts` — restore stateful before `deleteObject`
- `src/handlers/RefactorHandlers.ts` — `JSON.parse` `range` / `proposal` / `refactoring`

## Test plan

Verified on a real NW system after \`npm run build\` and a client restart:

- [x] `lock` returns a real lockHandle (was: stateful error)
- [x] `setObjectSource` writes new source content; `getObjectSource` reflects the change (was: stateful error)
- [x] `unLock` releases (was: stateful error)
- [x] `extractMethodEvaluate` returns a server-side proposal with auto-detected returning param (was: TypeError)
- [x] `extractMethodPreview` returns the textReplaceDeltas (path was previously unreachable due to evaluate failure)
- [x] `extractMethodExecute` writes the new method definition + implementation; class re-reads with the refactor applied
- [x] `renameExecute` still works as before — no regression